### PR TITLE
Remove compilerPath from babel-plugin configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,6 @@ function emberIntegration(/* options */) {
 									[
 										"babel-plugin-ember-template-compilation",
 										{
-											compilerPath: "ember-source/dist/ember-template-compiler.js",
 											enableLegacyModules: [
 												"ember-cli-htmlbars",
 												"ember-cli-htmlbars-inline-precompile",


### PR DESCRIPTION
Removed compilerPath for babel-plugin-ember-template-compilation.

newer dependencies auto-discover the compiler