### PR TITLE
Allow configuring Embroider macros via a `configure` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,6 @@ import { ember as emberVite, extensions } from "@embroider/vite";
 import { babel } from "@rollup/plugin-babel";
 import { buildMacros } from "@embroider/macros/babel";
 
-const macros = buildMacros();
-
 function getRenderer() {
 	return {
 		name: "ember-astro",
@@ -19,7 +17,14 @@ export function getContainerRenderer() {
 	};
 }
 
-function emberIntegration(/* options */) {
+function emberIntegration(options = {}) {
+	// Forward a `configure` callback to buildMacros so consumers can register
+	// Embroider macros global config (e.g. WarpDrive/ember-data via `setConfig`).
+	// Needed when compiling apps/libs gated on `getGlobalConfig().<pkg>.env` —
+	// without it the build throws on that value being undefined. Omitting
+	// `configure` is identical to the previous `buildMacros()` call.
+	const macros = buildMacros({ configure: options.configure });
+
 	return {
 		name: "ember-astro",
 		hooks: {


### PR DESCRIPTION
## Why

`ember-astro` calls `buildMacros()` with no options, so consumers can't supply Embroider macros config. Compiling any Ember app/library gated on `getGlobalConfig()` then fails.

Concretely: importing a component library that depends on WarpDrive / ember-data — whose published code runs `macroCondition(getGlobalConfig().WarpDriveMirror.env.PRODUCTION)` — throws during the build:

```
@warp-drive-mirror/ember/dist/index.js: Cannot read properties of undefined (reading 'env')
```

because `getGlobalConfig().WarpDriveMirror` is undefined (no macros config was registered). A normal Ember app build supplies this via `ember-cli-build` / `setConfig`; there was no equivalent hook for the Astro integration.

## What

Forward a `configure` callback to `buildMacros({ configure })` (one of its documented options), so consumers can register global config:

```js
import { defineConfig } from 'astro/config';
import { ember } from 'ember-astro';
import { setConfig } from '@warp-drive/build-config'; // or your lib's macros setup

export default defineConfig({
  integrations: [ember({ configure: (macros) => setConfig(macros, {}) })],
});
```

The `buildMacros()` call also moves into the integration factory so the option is honored per-instantiation.

## Backward compatibility

Fully backward-compatible — when `configure` is omitted, `buildMacros({ configure: undefined })` behaves exactly as the previous `buildMacros()` call.

## Notes

Verified end-to-end: this is the only `ember-astro` change needed to compile a real Ember component library (that transitively pulls in WarpDrive) and render live examples inline in an Astro site. Happy to broaden this to a full `macros` options passthrough (`buildMacros(options.macros)` — exposing `setOwnConfig`/`setConfig`/`configure`) if you'd prefer that shape.